### PR TITLE
Changing auth construction to use alteryx encryption / decryption

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "babel": "^6.23.0",
     "babel-core": "^6.26.0",
     "babel-loader": "^7.1.2",
+    "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-preset-env": "^1.6.1",
     "cross-env": "^5.0.5",
     "css-loader": "^0.28.7",

--- a/src/components/JiraConnection.vue
+++ b/src/components/JiraConnection.vue
@@ -101,22 +101,18 @@
       },
       username: {
         get () {
-          return atob(this.$store.state.ui.auth).substr(0,atob(this.$store.state.ui.auth).indexOf(':'))
+          return this.$store.state.ui.username
         },
         set (value) {
-          var pass = atob(this.$store.state.ui.auth).substr(atob(this.$store.state.ui.auth).indexOf(':')+1)
-          var auth = btoa(value + ':' + pass)
-          this.$store.commit('updateAuth', auth)
+          this.$store.commit('updateUsername', value)
         }
       },
       password: {
         get () {
-          return atob(this.$store.state.ui.auth).substr(atob(this.$store.state.ui.auth).indexOf(':')+1)
+          return this.$store.state.ui.password
         },
         set (value) {
-          var user = atob(this.$store.state.ui.auth).substr(0,atob(this.$store.state.ui.auth).indexOf(':'))
-          var auth = btoa(user + ':' + value)
-          this.$store.commit('updateAuth', auth)
+          this.$store.commit('updatePassword', value)
         }
       },
       urlErrors () {
@@ -144,12 +140,12 @@
         this.loading = true
 
         // Projects
-        axios.get(this.$store.state.ui.url + '/rest/api/latest/project?expand=description', 
+        axios.get(this.$store.state.ui.url + '/rest/api/latest/project?expand=description',
           {
-            'headers': { 
+            'headers': {
                 'Content-Type': 'application/json',
                 'Authorization': 'Basic ' + this.$store.state.ui.auth
-            } 
+            }
           })
         .then(response => {
                             this.$store.commit('updateConnected',1)
@@ -178,4 +174,3 @@
     }
   }
 </script>
-

--- a/src/components/JiraUpdate.vue
+++ b/src/components/JiraUpdate.vue
@@ -8,8 +8,8 @@
           multi-line
         >
           UPDATE AVAILABLE
-          <v-btn 
-            flat 
+          <v-btn
+            flat
             color="yellow"
             @click.native="showInfo"
             >
@@ -24,17 +24,17 @@
           <v-card>
             <div class="headline pl-3 pt-3">
               Update Available<small class="grey--text ml-2">{{ curVersion }}<v-icon>arrow_right</v-icon>{{ updateVersion }}</small>
-              <v-btn 
-                dark 
-                fab 
+              <v-btn
+                dark
+                fab
                 fixed
                 small
-                top 
-                right 
-                color="red darken-1" 
+                top
+                right
+                color="red darken-1"
                 @click.native="moreInfo = false">
                   <v-icon>close</v-icon>
-              </v-btn>                  
+              </v-btn>
             </div>
             <v-card-text class="pt-3">
               <code>{{ updateUrl }}</code><br>
@@ -107,7 +107,7 @@
       },
       updated() {
         // return this.$store.state.ui.version != this.$store.state.config.appVersion
-        return (this.$store.state.ui.version.length > 0 && this.$store.state.ui.version != this.$store.state.config.appVersion);
+        return (this.$store.state.ui.version && this.$store.state.ui.version.length > 0 && this.$store.state.ui.version != this.$store.state.config.appVersion);
       },
       curVersion() {
         return this.$store.state.config.appVersion

--- a/src/main.js
+++ b/src/main.js
@@ -12,7 +12,7 @@ Vue.use(Vuelidate)
 
 // GET latest release info for update check
 axios.get(store.state.config.latestUrl)
-.then(response => { 
+.then(response => {
 					const avail = response.data.name
 					const current = store.state.config.appVersion
 					store.state.config.updateAvail = (avail.length > 0 && avail !== current) ? true : false
@@ -29,25 +29,48 @@ const app = new Vue({
   render: h => h(App)
 })
 
-window.Alteryx.Gui = {
+window.Alteryx.Gui = window.Alteryx.Gui || {}
 
-	SetConfiguration: j => {
+window.Alteryx.Gui.BeforeLoad = function (manager, AlteryxDataItems, json) {
+  const handleEncryptedConfigField = (configFieldName) => {
+    const encryptedDataItem = new AlteryxDataItems.SimpleString(configFieldName, { password: true })
+    encryptedDataItem.fromJson(
+      resolvedDecryptionValue => {
+        store.state.ui[configFieldName] = resolvedDecryptionValue
+      },
+      rejectedDecryption => {},
+      store.state.ui[configFieldName]
+    )
+    manager.addDataItem(encryptedDataItem)
+  }
 
-		// update Vuex store with Alteryx Designer XML config, if exists
-		store.state.ui = j.Configuration.Configuration ? j.Configuration.Configuration : store.state.ui
-		window.Alteryx.JsEvent(JSON.stringify({Event: 'SetConfiguration'}))
+  store.state.ui = json.Configuration || store.state.ui
+  handleEncryptedConfigField('password')
+  handleEncryptedConfigField('username')
+  handleEncryptedConfigField('auth')
+  handleEncryptedConfigField('lastAuth')
+}
 
-	},
-	GetConfiguration: () => {
+window.Alteryx.Gui.GetConfiguration = (configObj) => {
+  // fill in data items with latest values so encryption pass encrypts them
+  window.Alteryx.Gui.Manager.getDataItem('password').setValue(store.state.ui.password)
+  window.Alteryx.Gui.Manager.getDataItem('username').setValue(store.state.ui.username)
+  window.Alteryx.Gui.Manager.getDataItem('auth').setValue(store.state.ui.auth)
+  window.Alteryx.Gui.Manager.getDataItem('lastAuth').setValue(store.state.ui.lastAuth)
 
-		// give Vuex store to the Alteryx Designer XML config
-		window.Alteryx.JsEvent(JSON.stringify({
-			Event: 'GetConfiguration',
-			Configuration: {
-				Configuration: store.state.ui,
-				Annotation: store.state.config.appTitle
-			}
-		}))
-	}
-
+  window.Alteryx.Gui.Manager.toJson(
+    resolvedJson => {
+      // resolvedJson has encrypted elements in it
+      // give Vuex store to the Alteryx Designer XML config
+      window.Alteryx.JsEvent(JSON.stringify({
+        Event: 'GetConfiguration',
+        Configuration: {
+          Configuration: { ...store.state.ui, ...resolvedJson.Configuration},
+          Annotation: store.state.config.appTitle
+        }
+      }))
+    },
+    rejectedJson => {},
+    false //macroMode - is this a macro backend tool? No.
+  )
 }

--- a/src/store.js
+++ b/src/store.js
@@ -30,7 +30,8 @@ export const store = new Vuex.Store({
 			page: 'connection',
 			url: 'https://alteryx-vue.atlassian.net',
 			lastUrl: '',
-			auth: '',
+      username: '',
+      password: '',
 			lastAuth: '',
 			connected: 0,
 			connects: 0,
@@ -63,15 +64,14 @@ export const store = new Vuex.Store({
 	  },
 	  updateUsername (state, v) {
 	    state.ui.username = v
+      state.ui.auth = state.ui.username + state.ui.password
 	  },
 	  updatePassword (state, v) {
 	    state.ui.password = v
-	  },
-	  updateAuth (state, v) {
-	    state.ui.auth = v
+      state.ui.auth = state.ui.username + state.ui.password
 	  },
 	  updateLastAuth (state) {
-	  	state.ui.lastAuth = state.ui.auth
+	  	state.ui.lastAuth = auth//state.ui.username + state.ui.password
 	  },
 	  updateConnected (state, v) {
 	    state.ui.connected = v

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -32,7 +32,8 @@ module.exports = {
         use: {
           loader: 'babel-loader',
           options: {
-            presets: ['env']
+            presets: ['env'],
+            plugins: ['transform-object-rest-spread']
           }
         }
       },


### PR DESCRIPTION
Added a spread operator plugin for babel to use the spread operator in overlapping sections of the config object sent back to Alteryx.

Changed the way auth is constructed into a concatenation for hash keying, a delimiter contained in it would actually be more accurate.. It ought to work for the moment. It should likely include the URL in the construction as well to guarantee it identifies state of previous auth.